### PR TITLE
S-118689 create missing paths before writing file

### DIFF
--- a/git/commands.go
+++ b/git/commands.go
@@ -45,6 +45,12 @@ func (c *WriteFileCommand) execute(ctx *GitContext) error {
 	}
 
 	absPath := filepath.Join(worktree.Filesystem.Root(), c.FilePath)
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		err := os.MkdirAll(filepath.Dir(absPath), os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
 	err = os.WriteFile(absPath, c.Content, os.ModePerm)
 	if err != nil {
 		return err

--- a/git/commands_test.go
+++ b/git/commands_test.go
@@ -67,6 +67,22 @@ func TestWriteFileCommand(t *testing.T) {
 	assert.Equal(t, content, readContent)
 }
 
+func TestWriteFileToNestedPathCommand(t *testing.T) {
+	ctx := setupTestRepo(t)
+	defer ctx.Cleanup()
+
+	filePath := "nested/nonExisting/path/testfile.txt"
+	content := []byte("Hello, World!")
+
+	cmd := &WriteFileCommand{FilePath: filePath, Content: content}
+	err := ctx.ExecuteCommand(cmd)
+	assert.NoError(t, err)
+
+	readContent, err := os.ReadFile(ctx.repositoryPath + "/" + filePath)
+	assert.NoError(t, err)
+	assert.Equal(t, content, readContent)
+}
+
 func TestAddFilesCommand(t *testing.T) {
 	ctx := setupTestRepo(t)
 	defer ctx.Cleanup()


### PR DESCRIPTION
WriteFile did not create intermediate paths, fixed it by first checking if path exists